### PR TITLE
skip empty pages

### DIFF
--- a/src/components/pages/AudioReviewPage.tsx
+++ b/src/components/pages/AudioReviewPage.tsx
@@ -7,6 +7,8 @@ import { styled } from "@stitches/react";
 import { useNavigate } from "react-router-dom";
 import { useErrorBoundary } from "react-error-boundary";
 
+const NEXT_PAGE = '/music-videos'
+
 export default function AudioReviewPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -18,7 +20,11 @@ export default function AudioReviewPage() {
     const setup = async (): Promise<void> => {
       setIsLoading(true);
       try {
-        setAudios(await listAudio());
+        const fetched = await listAudio();
+        if (!fetched.length) {
+          void navigate(NEXT_PAGE);
+        }
+        setAudios(fetched);
       } catch (e) {
         showBoundary(e);
       } finally {
@@ -85,7 +91,7 @@ export default function AudioReviewPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/music-videos");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Music Videos

--- a/src/components/pages/FavoriteActorsPage.tsx
+++ b/src/components/pages/FavoriteActorsPage.tsx
@@ -11,7 +11,7 @@ import { generateGuid } from "@/lib/utils";
 import { BaseItemPerson } from "@jellyfin/sdk/lib/generated-client";
 import { ActorCard } from "./MoviesReviewPage/ActorCard";
 import { useErrorBoundary } from "react-error-boundary";
-
+const NEXT_PAGE = '/genres';
 export default function FavoriteActorsPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -30,7 +30,11 @@ export default function FavoriteActorsPage() {
     const setup = async () => {
       setIsLoading(true);
       try {
-        setFavoriteActors(await listFavoriteActors());
+        const fetched = await listFavoriteActors();
+        if (!fetched.length) {
+          void navigate(NEXT_PAGE);
+        }
+        setFavoriteActors(fetched);
       } catch (e) {
         showBoundary(e);
       } finally {
@@ -87,7 +91,7 @@ export default function FavoriteActorsPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/genres");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Top Genres

--- a/src/components/pages/GenreReviewPage.tsx
+++ b/src/components/pages/GenreReviewPage.tsx
@@ -13,6 +13,7 @@ import { generateGuid } from "@/lib/utils";
 import { useErrorBoundary } from "react-error-boundary";
 import { getCachedHiddenIds, setCachedHiddenId } from "@/lib/cache";
 
+const NEXT_PAGE = '/holidays';
 export default function GenreReviewPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -35,6 +36,9 @@ export default function GenreReviewPage() {
             .map((show) => show.item)
             .filter((show) => !hiddenIds.includes(show.id ?? "")),
         );
+        if (!movies.length && !shows.length) {
+          void navigate(NEXT_PAGE);
+        }
       } catch (error) {
         showBoundary(error);
       } finally {
@@ -121,7 +125,7 @@ export default function GenreReviewPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/holidays");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Holidays

--- a/src/components/pages/HolidayReviewPage.tsx
+++ b/src/components/pages/HolidayReviewPage.tsx
@@ -17,6 +17,8 @@ import {
   getValentinesDay,
 } from "date-fns-holiday-us";
 import { isAfter, isSameDay, subDays } from "date-fns";
+
+const NEXT_PAGE = '/tv';
 export default function HolidayReviewPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -87,6 +89,9 @@ export default function HolidayReviewPage() {
         setValentinesItems(
           valentinesItems.filter((item) => !hiddenIds.includes(item.id ?? "")),
         );
+        if (christmasItems.length === 0 && christmasEveItems.length === 0 && halloweenItems.length === 0 && valentinesItems.length === 0) {
+          void navigate(NEXT_PAGE);
+        }
       } catch (error) {
         showBoundary(error);
       } finally {
@@ -200,7 +205,7 @@ export default function HolidayReviewPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/tv");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Live TV

--- a/src/components/pages/LiveTvReviewPage.tsx
+++ b/src/components/pages/LiveTvReviewPage.tsx
@@ -13,6 +13,7 @@ interface ChannelCardProps {
   duration: number;
 }
 
+const NEXT_PAGE = '/audio';
 export function ChannelCard({ channelName, duration }: ChannelCardProps) {
   return (
     <motion.div
@@ -48,6 +49,9 @@ export default function LiveTvReviewPage() {
         const channelData = await listLiveTvChannels();
         // Sort channels by duration in descending order
         channelData.sort((a, b) => b.duration - a.duration);
+        if (!channelData.length) {
+          void navigate(NEXT_PAGE);
+        }
         setChannels(channelData);
       } catch (e) {
         showBoundary(e);
@@ -108,7 +112,7 @@ export default function LiveTvReviewPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/audio");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Audio

--- a/src/components/pages/MoviesReviewPage.tsx
+++ b/src/components/pages/MoviesReviewPage.tsx
@@ -9,6 +9,7 @@ import { generateGuid } from "@/lib/utils";
 import { useErrorBoundary } from "react-error-boundary";
 import { getCachedHiddenIds, setCachedHiddenId } from "@/lib/cache";
 
+const NEXT_PAGE = '/oldest-movie'
 export default function MoviesReviewPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -24,6 +25,9 @@ export default function MoviesReviewPage() {
         setMovies(
           movies.filter((movie) => !hiddenIds.includes(movie.id ?? "")),
         );
+        if (!movies.length) {
+          void navigate(NEXT_PAGE);
+        }
       } catch (error) {
         showBoundary(error);
       } finally {
@@ -79,7 +83,7 @@ export default function MoviesReviewPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/oldest-movie");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Oldest Movie

--- a/src/components/pages/MusicVideoPage.tsx
+++ b/src/components/pages/MusicVideoPage.tsx
@@ -10,6 +10,7 @@ import { styled } from "@stitches/react";
 import { useNavigate } from "react-router-dom";
 import { useErrorBoundary } from "react-error-boundary";
 
+const NEXT_PAGE = "/";
 export default function MusicVideoPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -21,7 +22,11 @@ export default function MusicVideoPage() {
     const setup = async () => {
       setIsLoading(true);
       try {
-        setMusicVideos(await listMusicVideos());
+        const fetched = await listMusicVideos();
+        if (!fetched.length) {
+          void navigate(NEXT_PAGE);
+        }
+        setMusicVideos(fetched);
       } catch (error) {
         showBoundary(error);
       } finally {
@@ -88,7 +93,7 @@ export default function MusicVideoPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/");
+          void navigate(NEXT_PAGE);
         }}
       >
         Home

--- a/src/components/pages/OldestMoviePage.tsx
+++ b/src/components/pages/OldestMoviePage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 import { Subtitle } from "../ui/styled";
 import { useErrorBoundary } from "react-error-boundary";
 
+const NEXT_PAGE = "/shows";
 export default function OldestMoviePage() {
   const { showBoundary } = useErrorBoundary();
 
@@ -26,6 +27,9 @@ export default function OldestMoviePage() {
           return aDate.getTime() - bDate.getTime();
         });
         const m = movies.find((s) => s);
+        if (!m) {
+          void navigate(NEXT_PAGE);
+        }
         setMovie(m);
       } catch (e) {
         showBoundary(e);
@@ -79,7 +83,7 @@ export default function OldestMoviePage() {
           size={"4"}
           style={{ width: "100%" }}
           onClick={() => {
-            void navigate("/shows");
+            void navigate(NEXT_PAGE);
           }}
         >
           Review Shows
@@ -121,7 +125,7 @@ export default function OldestMoviePage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/shows");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Shows

--- a/src/components/pages/OldestShowPage.tsx
+++ b/src/components/pages/OldestShowPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 import { Subtitle } from "../ui/styled";
 import { useErrorBoundary } from "react-error-boundary";
 
+const NEXT_PAGE = "/actors";
 export default function OldestShowPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -30,6 +31,9 @@ export default function OldestShowPage() {
           return aDate.getTime() - bDate.getTime();
         });
         const s = shows.find((s) => s);
+        if (!s) {
+          void navigate(NEXT_PAGE);
+        }
         setShow(s);
       } catch (e) {
         showBoundary(e);
@@ -82,7 +86,7 @@ export default function OldestShowPage() {
           size={"4"}
           style={{ width: "100%" }}
           onClick={() => {
-            void navigate("/actors");
+            void navigate(NEXT_PAGE);
           }}
         >
           Review Favorite Actors
@@ -130,7 +134,7 @@ export default function OldestShowPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/actors");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Favorite Actors

--- a/src/components/pages/ServerConfigurationPage.tsx
+++ b/src/components/pages/ServerConfigurationPage.tsx
@@ -17,6 +17,9 @@ import {
   setCacheValue,
 } from "@/lib/cache";
 import { useErrorBoundary } from "react-error-boundary";
+import { listAudio, listLiveTvChannels, listMovies, listShows } from "@/lib/playback-reporting-queries";
+
+const NEXT_PAGE = '/movies'
 type WindowOverride = typeof Window & {
   ENV:
     | {
@@ -81,7 +84,13 @@ const ServerConfigurationPage = () => {
         await authenticateByUserName(serverUrl, username, password);
       }
 
-      void navigate("/movies");
+      // Warm caches
+      void listMovies();
+      void listShows();
+      void listAudio();
+      void listLiveTvChannels();
+
+      void navigate(NEXT_PAGE);
     } catch (e) {
       showBoundary(e);
     } finally {

--- a/src/components/pages/ShowReviewPage.tsx
+++ b/src/components/pages/ShowReviewPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 import { useErrorBoundary } from "react-error-boundary";
 import { getCachedHiddenIds, setCachedHiddenId } from "@/lib/cache";
 
+const NEXT_PAGE = "/oldest-show";
 export default function ShowReviewPage() {
   const { showBoundary } = useErrorBoundary();
   const navigate = useNavigate();
@@ -31,6 +32,9 @@ export default function ShowReviewPage() {
           (show) => !hiddenIds.includes(show.item.id ?? ""),
         );
         setShows(filteredShows);
+        if (!filteredShows.length) {
+          void navigate(NEXT_PAGE);
+        }
       } catch (e) {
         showBoundary(e);
       } finally {
@@ -110,7 +114,7 @@ export default function ShowReviewPage() {
         size={"4"}
         style={{ width: "100%" }}
         onClick={() => {
-          void navigate("/oldest-show");
+          void navigate(NEXT_PAGE);
         }}
       >
         Review Oldest Show

--- a/src/components/pages/SplashPage.tsx
+++ b/src/components/pages/SplashPage.tsx
@@ -12,6 +12,7 @@ import {
   Title,
 } from "../ui/styled";
 
+const NEXT_PAGE = "/configure";
 const SplashPage = () => {
   const navigate = useNavigate();
 
@@ -101,7 +102,7 @@ const SplashPage = () => {
         >
           <StyledButton
             onClick={() => {
-              void navigate("/configure");
+              void navigate(NEXT_PAGE);
             }}
           >
             Connect Your Jellyfin Server


### PR DESCRIPTION
Some people have not used certain categories at all, such as audio, music videos, live tv. It can be confusing to show pages like "You watched zero music videos".

Instead we should skip those pages entirely. This PR accomplishes that.