### PR TITLE
fix: show graceful empty states instead of blank pages

### DIFF
--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,49 @@
+import { Container, Grid } from "@radix-ui/themes";
+import { motion } from "framer-motion";
+import { Title } from "./ui/styled";
+import PageContainer from "./PageContainer";
+
+interface EmptyStateProps {
+  title: string;
+  message?: string;
+  backgroundColor?: string;
+  nextPage?: string;
+  previousPage?: string;
+}
+
+export default function EmptyState({
+  title,
+  message = "No activity found for this category. Keep watching and check back later!",
+  backgroundColor = "var(--gray-8)",
+  nextPage,
+  previousPage,
+}: EmptyStateProps) {
+  return (
+    <PageContainer
+      backgroundColor={backgroundColor}
+      nextPage={nextPage}
+      previousPage={previousPage}
+    >
+      <Container size="4" p="4">
+        <Grid gap="4" style={{ textAlign: "center", paddingTop: "20vh" }}>
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.5 }}
+          >
+            <Title as={motion.h1}>{title}</Title>
+            <p
+              style={{
+                fontSize: "1.125rem",
+                color: "var(--gray-11)",
+                marginTop: "1rem",
+              }}
+            >
+              {message}
+            </p>
+          </motion.div>
+        </Grid>
+      </Container>
+    </PageContainer>
+  );
+}

--- a/src/components/pages/AudioReviewPage.tsx
+++ b/src/components/pages/AudioReviewPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
@@ -26,8 +27,14 @@ export default function AudioReviewPage() {
   }
 
   if (!audios?.length) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Audio Listening History"
+        backgroundColor="var(--red-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/shows"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/CriticallyAcclaimedPage.tsx
+++ b/src/components/pages/CriticallyAcclaimedPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import {
   Container,
   Grid,
@@ -43,8 +44,14 @@ export default function CriticallyAcclaimedPage() {
   const topContent = getTopRatedContent(movies ?? [], shows ?? []);
 
   if (!topContent.length) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Critically Acclaimed Titles"
+        backgroundColor="var(--cyan-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/tv"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/DeviceStatsPage.tsx
+++ b/src/components/pages/DeviceStatsPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useRef } from "react";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -34,8 +35,14 @@ export default function DeviceStatsPage() {
   }
 
   if (!deviceStats) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Device Stats"
+        backgroundColor="var(--violet-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/unfinished-shows"
+      />
+    );
   }
 
   const containerWidth = containerRef.current?.clientWidth || 600;

--- a/src/components/pages/FavoriteActorsPage.tsx
+++ b/src/components/pages/FavoriteActorsPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
@@ -20,11 +21,16 @@ export default function FavoriteActorsPage() {
   const navigate = useNavigate();
   const { data: favoriteActors, isLoading, error } = useFavoriteActors();
 
-  useEffect(() => {
-    if (!isLoading && !error && favoriteActors && !favoriteActors.length) {
-      void navigate(NEXT_PAGE);
-    }
-  }, [isLoading, error, favoriteActors, navigate]);
+  if (!isLoading && !error && favoriteActors && !favoriteActors.length) {
+    return (
+      <EmptyState
+        title="No Favorite Actors Yet"
+        backgroundColor="var(--orange-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/music-videos"
+      />
+    );
+  }
 
   if (error) {
     showBoundary(error);

--- a/src/components/pages/GenreReviewPage.tsx
+++ b/src/components/pages/GenreReviewPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useState } from "react";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -52,8 +53,14 @@ export default function GenreReviewPage() {
   const topGenreData = getTopGenre(visibleMovies, visibleShows);
 
   if (!topGenreData) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Genre Data"
+        backgroundColor="var(--pink-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/actors"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/HolidayReviewPage.tsx
+++ b/src/components/pages/HolidayReviewPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useState, useMemo } from "react";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -78,8 +79,14 @@ export default function HolidayReviewPage() {
     !halloweenItems.length &&
     !valentinesItems.length
   ) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Holiday Viewing Data"
+        backgroundColor="var(--grass-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/oldest-show"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/LiveTvReviewPage.tsx
+++ b/src/components/pages/LiveTvReviewPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import {
   Container,
   Grid,
@@ -62,8 +63,14 @@ export default function LiveTvReviewPage() {
   );
 
   if (!sortedChannels.length) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Live TV Activity"
+        backgroundColor="var(--blue-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/genres"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/MinutesPlayedPerDayPage.tsx
+++ b/src/components/pages/MinutesPlayedPerDayPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useRef } from "react";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -47,8 +48,14 @@ export default function MinutesPlayedPerDayPage() {
   }
 
   if (!playbackData || !viewingPatterns) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Daily Viewing Data"
+        backgroundColor="var(--amber-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/holidays"
+      />
+    );
   }
 
   const containerWidth = containerRef.current?.clientWidth || 600;

--- a/src/components/pages/MoviesReviewPage.tsx
+++ b/src/components/pages/MoviesReviewPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useState } from "react";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -34,8 +35,14 @@ export default function MoviesReviewPage() {
     ) ?? [];
 
   if (!visibleMovies.length) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Movies Watched"
+        backgroundColor="var(--purple-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/TopTen"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/MusicVideoPage.tsx
+++ b/src/components/pages/MusicVideoPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
@@ -25,8 +26,14 @@ export default function MusicVideoPage() {
   }
 
   if (!musicVideos?.length) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Music Videos Watched"
+        backgroundColor="var(--red-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/audio"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/OldestMoviePage.tsx
+++ b/src/components/pages/OldestMoviePage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
@@ -35,8 +36,14 @@ export default function OldestMoviePage() {
   const movie = sortedMovies[0];
 
   if (!movie) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Movie History"
+        backgroundColor="var(--teal-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/critically-acclaimed"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/OldestShowPage.tsx
+++ b/src/components/pages/OldestShowPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
@@ -36,8 +37,14 @@ export default function OldestShowPage() {
   const show = sortedShows[0];
 
   if (!show) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Show History"
+        backgroundColor="var(--lime-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/oldest-movie"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/PunchCardPage.tsx
+++ b/src/components/pages/PunchCardPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { ResponsiveScatterPlot } from "@nivo/scatterplot";
 import { Card } from "@/components/ui/card";
 import { Button, Box } from "@radix-ui/themes";

--- a/src/components/pages/ShowOfTheMonthPage.tsx
+++ b/src/components/pages/ShowOfTheMonthPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useEffect, useState } from "react";
 import { Container, Grid, Card, Text } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -59,8 +60,14 @@ export default function ShowOfTheMonthPage() {
   }
 
   if (!statsWithPosters.length) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Show of the Month Data"
+        backgroundColor="var(--bronze-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/minutes-per-day"
+      />
+    );
   }
 
   return (

--- a/src/components/pages/ShowReviewPage.tsx
+++ b/src/components/pages/ShowReviewPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useState, useEffect } from "react";
 import { Container, Grid } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -25,11 +26,16 @@ export default function ShowReviewPage() {
         !hiddenIds.includes(show.item.id ?? "")
     ) ?? [];
 
-  useEffect(() => {
-    if (!isLoading && !error && shows && !visibleShows.length) {
-      void navigate(NEXT_PAGE);
-    }
-  }, [isLoading, error, shows, visibleShows.length, navigate]);
+  if (!isLoading && !error && shows && !visibleShows.length) {
+    return (
+      <EmptyState
+        title="No Shows Watched"
+        backgroundColor="var(--yellow-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/movies"
+      />
+    );
+  }
 
   if (error) {
     showBoundary(error);

--- a/src/components/pages/UnfinishedShowsPage.tsx
+++ b/src/components/pages/UnfinishedShowsPage.tsx
@@ -1,3 +1,4 @@
+import EmptyState from "../EmptyState";
 import { useEffect, useState } from "react";
 import { Container, Grid, Card, Text } from "@radix-ui/themes";
 import { motion } from "framer-motion";
@@ -50,8 +51,14 @@ export default function UnfinishedShowsPage() {
   }
 
   if (!showsWithPosters.length) {
-    void navigate(NEXT_PAGE);
-    return null;
+    return (
+      <EmptyState
+        title="No Unfinished Shows"
+        backgroundColor="var(--plum-8)"
+        nextPage={NEXT_PAGE}
+        previousPage="/show-of-the-month"
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
When a page has no data (e.g., no Live TV activity, no audio history), it previously auto-navigated to the next page via `navigate(NEXT_PAGE)`. This caused blank screens when multiple consecutive pages had no data, and the Previous/Next buttons would disappear.

Now each page shows a styled empty state with:
- The category title (e.g., "No Live TV Activity")
- A friendly message
- Working Previous/Next navigation buttons

Affected 16 pages across all categories.

Closes #31